### PR TITLE
rename entity library magic comment

### DIFF
--- a/lib/languageFeatures/completion.ts
+++ b/lib/languageFeatures/completion.ts
@@ -40,7 +40,7 @@ export function attachOnCompletion() {
       if (match) {
         for (const pkg of projectParser.getPackages()) {
           completions.push({ label: pkg.lexerToken.text });
-          pkg.library && completions.push({ label: pkg.library });
+          pkg.targetLibrary && completions.push({ label: pkg.targetLibrary });
         }
       }
       completions.push({ label: 'all' });

--- a/lib/parser/objects.ts
+++ b/lib/parser/objects.ts
@@ -346,7 +346,7 @@ export class OPackage extends ObjectBase implements IHasSubprograms, IHasCompone
   genericRange?: OIRange;
   generics: OGeneric[] = [];
   genericAssociationList?: OGenericAssociationList;
-  library?: string;
+  targetLibrary?: string;
 }
 
 export class OPackageBody extends ObjectBase implements IHasSubprograms, IHasConstants, IHasVariables, IHasTypes,
@@ -363,7 +363,7 @@ export class OPackageBody extends ObjectBase implements IHasSubprograms, IHasCon
   variables: OVariable[] = [];
   types: OType[] = [];
   files: OFileVariable[] = [];
-  library?: string;
+  targetLibrary?: string;
   correspondingPackage?: OPackage;
 }
 export class OUseClause extends ObjectBase implements IHasLibraryReference {
@@ -707,7 +707,7 @@ export class OAssociation extends ObjectBase implements IHasDefinitions {
 }
 export class OEntity extends ObjectBase implements IHasDefinitions, IHasSubprograms, IHasSignals, IHasConstants, IHasVariables,
   IHasTypes, IHasFileVariables, IHasUseClauses, IHasContextReference, IHasLexerToken, IHasPackageInstantiations, IHasLibraries {
-  constructor(public parent: OFile, range: OIRange, public libraryMagicComment?: string) {
+  constructor(public parent: OFile, range: OIRange, public targetLibrary?: string) {
     super(parent, range);
   }
   libraries: OLexerToken[] = [];

--- a/lib/parser/objects.ts
+++ b/lib/parser/objects.ts
@@ -707,7 +707,7 @@ export class OAssociation extends ObjectBase implements IHasDefinitions {
 }
 export class OEntity extends ObjectBase implements IHasDefinitions, IHasSubprograms, IHasSignals, IHasConstants, IHasVariables,
   IHasTypes, IHasFileVariables, IHasUseClauses, IHasContextReference, IHasLexerToken, IHasPackageInstantiations, IHasLibraries {
-  constructor(public parent: OFile, range: OIRange, public library?: string) {
+  constructor(public parent: OFile, range: OIRange, public libraryMagicComment?: string) {
     super(parent, range);
   }
   libraries: OLexerToken[] = [];

--- a/lib/parser/package-parser.ts
+++ b/lib/parser/package-parser.ts
@@ -10,7 +10,7 @@ export class PackageParser extends ParserBase {
     if (nextToken.getLText() === 'body') {
       const pkg = new OPackageBody(parent, this.getToken().range);
       const match = parent.originalText.match(/!\s*@library\s+(\S+)/i);
-      pkg.library = match ? match[1] : undefined;
+      pkg.targetLibrary = match ? match[1] : undefined;
 
       pkg.lexerToken = this.consumeToken();
       this.expect('is');
@@ -26,7 +26,7 @@ export class PackageParser extends ParserBase {
     } else {
       const pkg = new OPackage(parent, this.getToken().range);
       const match = parent.originalText.match(/!\s*@library\s+(\S+)/i);
-      pkg.library = match ? match[1] : undefined;
+      pkg.targetLibrary = match ? match[1] : undefined;
 
       pkg.lexerToken = nextToken;
       this.expect('is');

--- a/lib/vhdl-linter.ts
+++ b/lib/vhdl-linter.ts
@@ -568,7 +568,7 @@ export class VhdlLinter {
   async checkLibrary() {
     const settings = await getDocumentSettings(URI.file(this.editorPath).toString());
     for (const entity of this.file.entities) {
-      if (settings.rules.warnLibrary && this.file && entity !== undefined && typeof entity.library === 'undefined') {
+      if (settings.rules.warnLibrary && entity !== undefined && typeof entity.libraryMagicComment === 'undefined') {
         this.addMessage({
           range: new OIRange(this.file, new OI(this.file, 0, 0), new OI(this.file, 1, 0)),
           severity: DiagnosticSeverity.Warning,
@@ -1370,8 +1370,8 @@ export class VhdlLinter {
     const projectEntities = this.projectParser.getEntities();
     if (instantiation instanceof OInstantiation && typeof instantiation.library !== 'undefined' && instantiation.library.getLText() !== 'work') {
       entities.push(...projectEntities.filter(entity => {
-        if (entity.library !== undefined) {
-          return entity.library.toLowerCase() === instantiation.library?.getLText() ?? '';
+        if (typeof entity.libraryMagicComment !== 'undefined') {
+          return entity.libraryMagicComment.toLowerCase() === instantiation.library?.getLText() ?? '';
         }
         return true;
 

--- a/lib/vhdl-linter.ts
+++ b/lib/vhdl-linter.ts
@@ -568,7 +568,7 @@ export class VhdlLinter {
   async checkLibrary() {
     const settings = await getDocumentSettings(URI.file(this.editorPath).toString());
     for (const entity of this.file.entities) {
-      if (settings.rules.warnLibrary && entity !== undefined && typeof entity.libraryMagicComment === 'undefined') {
+      if (settings.rules.warnLibrary && entity !== undefined && typeof entity.targetLibrary === 'undefined') {
         this.addMessage({
           range: new OIRange(this.file, new OI(this.file, 0, 0), new OI(this.file, 1, 0)),
           severity: DiagnosticSeverity.Warning,
@@ -1370,8 +1370,8 @@ export class VhdlLinter {
     const projectEntities = this.projectParser.getEntities();
     if (instantiation instanceof OInstantiation && typeof instantiation.library !== 'undefined' && instantiation.library.getLText() !== 'work') {
       entities.push(...projectEntities.filter(entity => {
-        if (typeof entity.libraryMagicComment !== 'undefined') {
-          return entity.libraryMagicComment.toLowerCase() === instantiation.library?.getLText() ?? '';
+        if (typeof entity.targetLibrary !== 'undefined') {
+          return entity.targetLibrary.toLowerCase() === instantiation.library?.getLText() ?? '';
         }
         return true;
 

--- a/lib/vhdl-linter.ts
+++ b/lib/vhdl-linter.ts
@@ -816,7 +816,7 @@ export class VhdlLinter {
             'add use statement for ' + pkg.lexerToken,
             {
               changes: {
-                [textDocumentUri]: [TextEdit.insert(pos, `use ${pkg.library ? pkg.library : 'work'}.${pkg.lexerToken}.all;\n`)]
+                [textDocumentUri]: [TextEdit.insert(pos, `use ${pkg.targetLibrary ? pkg.targetLibrary : 'work'}.${pkg.lexerToken}.all;\n`)]
               }
             },
             CodeActionKind.QuickFix
@@ -869,7 +869,7 @@ export class VhdlLinter {
             'add use statement for ' + pkg.lexerToken,
             {
               changes: {
-                [textDocumentUri]: [TextEdit.insert(pos, `use ${pkg.library ? pkg.library : 'work'}.${pkg.lexerToken}.all;\n`)]
+                [textDocumentUri]: [TextEdit.insert(pos, `use ${pkg.targetLibrary ? pkg.targetLibrary : 'work'}.${pkg.lexerToken}.all;\n`)]
               }
             },
             CodeActionKind.QuickFix


### PR DESCRIPTION
The entity library is only a string which contains the magic comment in which library this file is compiled. In `vhdl-linter.ts:checkLibraryReferences()` the function call `implementsIHasLibraryReference(object)` (line 126) will return true if a library magic comment exists as `obj.library` is not undefined. However, `obj.library` is assumed to be of type `OLexerToken` when in reality it is of type `string`. This results in a message "Library xyz not declared." with an undefined range (`range` does not exist on type `string`). This in turn results in no message being displayed; probably because vscode cannot handle error messages with undefined ranges...

Maybe, the `implements...` functions should check for the correct type instead of checking if the element is not `undefined`?