### PR TITLE
interpret function calls with return value as OInstantiation

### DIFF
--- a/test/test_files/test_error_expected/01/test_function_call.vhd
+++ b/test/test_files/test_error_expected/01/test_function_call.vhd
@@ -8,16 +8,16 @@ end entity;
 architecture rtl of test_function_call is
 begin
   process
-    function test(data: out std_ulogic) return std_ulogic is
+    function test(data: std_ulogic) return std_ulogic is
     begin
       data := '1';
       return data;
     end function;
 
-    variable s: std_ulogic; -- s should have 'not reading' warning
+    variable s: std_ulogic; -- s should have 'not written' warning
     variable x: std_ulogic;
   begin
-    x := test(data => s);
+    x := test(s);
     x := x;
   end process;
 

--- a/test/test_files/test_error_expected/01/test_function_call.vhd
+++ b/test/test_files/test_error_expected/01/test_function_call.vhd
@@ -1,0 +1,24 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity test_function_call is
+end entity;
+
+architecture rtl of test_function_call is
+begin
+  process
+    function test(data: out std_ulogic) return std_ulogic is
+    begin
+      data := '1';
+      return data;
+    end function;
+
+    variable s: std_ulogic; -- s should have 'not reading' warning
+    variable x: std_ulogic;
+  begin
+    x := test(data => s);
+    x := x;
+  end process;
+
+end architecture;


### PR DESCRIPTION
This addresses #35.
when the function calls return value is not used (just `test(data => s);` in line 20), it is parsed as `OInstantiation` and the warning in line 17 is produced as expected.