### PR TITLE
Better testing of find Definition

### DIFF
--- a/lib/language-server.ts
+++ b/lib/language-server.ts
@@ -1,5 +1,5 @@
 import {
-  CodeAction, createConnection, DefinitionLink, DidChangeConfigurationNotification, InitializeParams, LSPErrorCodes, Position, ProposedFeatures, ResponseError, TextDocuments, TextDocumentSyncKind
+  CodeAction, createConnection, DidChangeConfigurationNotification, InitializeParams, LSPErrorCodes, Position, ProposedFeatures, ResponseError, TextDocuments, TextDocumentSyncKind
 } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';

--- a/lib/languageFeatures/findDefinition.ts
+++ b/lib/languageFeatures/findDefinition.ts
@@ -7,18 +7,17 @@ import { findObjectFromPosition } from "./findObjectFromPosition";
 export async function findDefinitions(linter: VhdlLinter, position: Position): Promise<(DefinitionLink & { text: string; })[]> {
 
   const candidates = findObjectFromPosition(linter, position);
-  return candidates.flatMap(candidate => {
+  // Get unique definitions
+  const candidateDefinitions = [...new Set(candidates.flatMap(candidate => {
     if (implementsIHasDefinitions(candidate) && candidate.definitions) {
-      return candidate.definitions.map(definition => {
-        return {
-          targetRange: definition.range.copyExtendBeginningOfLine().getLimitedRange(10),
-          targetSelectionRange: definition.lexerToken?.range ?? definition.range.copyExtendBeginningOfLine().getLimitedRange(1),
-          text: definition.rootFile.originalText,
-          targetUri: URI.file(definition.rootFile.file).toString()
-        };
-      });
-    } else {
-      return [];
+      return candidate.definitions;
     }
-  });
+    return [];
+  }))];
+  return candidateDefinitions.flatMap(definition => ({
+    targetRange: definition.range.copyExtendBeginningOfLine().getLimitedRange(10),
+    targetSelectionRange: definition.lexerToken?.range ?? definition.range.copyExtendBeginningOfLine().getLimitedRange(1),
+    text: definition.rootFile.originalText,
+    targetUri: URI.file(definition.rootFile.file).toString()
+  }));
 }

--- a/lib/languageFeatures/findDefinition.ts
+++ b/lib/languageFeatures/findDefinition.ts
@@ -1,0 +1,24 @@
+import { DefinitionLink, Position } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+import { implementsIHasDefinitions } from "../parser/interfaces";
+import { VhdlLinter } from "../vhdl-linter";
+import { findObjectFromPosition } from "./findObjectFromPosition";
+
+export async function findDefinitions(linter: VhdlLinter, position: Position): Promise<(DefinitionLink & { text: string; })[]> {
+
+  const candidates = findObjectFromPosition(linter, position);
+  return candidates.flatMap(candidate => {
+    if (implementsIHasDefinitions(candidate) && candidate.definitions) {
+      return candidate.definitions.map(definition => {
+        return {
+          targetRange: definition.range.copyExtendBeginningOfLine().getLimitedRange(10),
+          targetSelectionRange: definition.lexerToken?.range ?? definition.range.copyExtendBeginningOfLine().getLimitedRange(1),
+          text: definition.rootFile.originalText,
+          targetUri: URI.file(definition.rootFile.file).toString()
+        };
+      });
+    } else {
+      return [];
+    }
+  });
+}

--- a/lib/languageFeatures/findObjectFromPosition.ts
+++ b/lib/languageFeatures/findObjectFromPosition.ts
@@ -4,7 +4,7 @@ import { VhdlLinter } from "../vhdl-linter";
 
 export function findObjectFromPosition(linter: VhdlLinter, position: Position): ObjectBase[] {
   const startI = linter.getIFromPosition(position);
-  let candidates = linter.file?.objectList.filter(object => object.range.start.i <= startI && startI <= object.range.end.i) ?? [];
+  let candidates = linter.file?.objectList.filter(object => object.range.start.i <= startI + 1 && startI <= object.range.end.i) ?? [];
   if (candidates.length === 0) {
     return [];
   }

--- a/lib/languageFeatures/findObjectFromPosition.ts
+++ b/lib/languageFeatures/findObjectFromPosition.ts
@@ -1,10 +1,13 @@
 import { Position } from "vscode-languageserver";
-import { ObjectBase } from "../parser/objects";
+import { OAssociation, ObjectBase } from "../parser/objects";
 import { VhdlLinter } from "../vhdl-linter";
 
 export function findObjectFromPosition(linter: VhdlLinter, position: Position): ObjectBase[] {
   const startI = linter.getIFromPosition(position);
-  let candidates = linter.file?.objectList.filter(object => object.range.start.i <= startI + 1 && startI <= object.range.end.i) ?? [];
+  let candidates = (linter.file?.objectList.filter(object => object.range.start.i <= startI + 1 && startI <= object.range.end.i) ?? [])
+  // If the association has no formal part its range is identical to the included reference.
+  // But we prefer to get the reference so explicity exclude Association here. (#197)
+    .filter(candidate => candidate instanceof OAssociation === false);
   if (candidates.length === 0) {
     return [];
   }

--- a/test/test.cov.ts
+++ b/test/test.cov.ts
@@ -31,8 +31,8 @@ async function run_test(path: string, error_expected: boolean, projectParser?: P
     if (argv.indexOf('--no-osvvm') > -1 && subPath.match(/OSVVM/i)) {
       continue;
     }
-    // Exclude OSVVM from resolved/unresolved checker
-    const getter = subPath.match(/OSVVM/i)
+    // Exclude OSVVM and IEEE from resolved/unresolved checker
+    const getter = subPath.match(/OSVVM/i) || subPath.match(/ieee/i)
       ? defaultSettingsWithOverwrite({ style: { preferredLogicTypePort: 'ignore', preferredLogicTypeSignal: 'ignore' } })
       : defaultSettingsGetter;
     if (lstatSync(subPath).isDirectory()) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -58,8 +58,8 @@ async function run_test(path: string, error_expected: boolean, projectParser?: P
     if (argv.indexOf('--no-osvvm') > -1 && subPath.match(/OSVVM/i)) {
       continue;
     }
-    // Exclude OSVVM from resolved/unresolved checker
-    const getter = subPath.match(/OSVVM/i)
+    // Exclude OSVVM and IEEE from resolved/unresolved checker
+    const getter = subPath.match(/OSVVM/i) || subPath.match(/ieee/i)
     ? defaultSettingsWithOverwrite({ style: { preferredLogicTypePort: 'ignore', preferredLogicTypeSignal: 'ignore' } })
     : defaultSettingsGetter;
     if (lstatSync(subPath).isDirectory()) {

--- a/test/unit_tests/definition/definition.test.ts
+++ b/test/unit_tests/definition/definition.test.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
   await projectParser.stop();
 });
 test(`Testing definitions`, async () => {
-  for (const character of [13, 14, 15]) {
+  for (const character of [13, 14, 15, 21, 22]) {
     const definition = await findDefinitions(linter, Position.create(12, character));
     expect(definition).toHaveLength(1);
     expect(definition[0].targetUri.replace(__dirname, '')).toBe('file:///definition.vhd');

--- a/test/unit_tests/definition/definition.test.ts
+++ b/test/unit_tests/definition/definition.test.ts
@@ -41,3 +41,7 @@ test(`Testing definition for literal actual without formal`, async () => {
   const definition = await findDefinitions(linter, Position.create(20, 7));
   expect(definition).toHaveLength(0);
 });
+test(`Testing definition for actual in instantiation which can not be elaborated`, async () => {
+  const definition = await findDefinitions(linter, Position.create(20, 7));
+  expect(definition).toHaveLength(0);
+});

--- a/test/unit_tests/definition/definition.test.ts
+++ b/test/unit_tests/definition/definition.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@jest/globals';
+import { beforeAll, expect, test } from '@jest/globals';
 import { readFileSync } from 'fs';
 import { Position } from 'vscode-languageserver';
 import { Elaborate } from '../../../lib/elaborate/elaborate';
@@ -6,19 +6,27 @@ import { findDefinitions } from '../../../lib/languageFeatures/findDefinition';
 import { ProjectParser } from '../../../lib/project-parser';
 import { defaultSettingsGetter } from '../../../lib/settings';
 import { VhdlLinter } from '../../../lib/vhdl-linter';
-
-test(`Testing definitions`, async () => {
-  const projectParser = await ProjectParser.create([__dirname], '', defaultSettingsGetter);
-  const linter = new VhdlLinter('definition.vhd', readFileSync(__dirname + '/definition.vhd', { encoding: 'utf8' }),
+let linter: VhdlLinter;
+let projectParser: ProjectParser;
+beforeAll(async () => {
+  projectParser = await ProjectParser.create([__dirname], '', defaultSettingsGetter);
+  linter = new VhdlLinter('definition.vhd', readFileSync(__dirname + '/definition.vhd', { encoding: 'utf8' }),
     projectParser, defaultSettingsGetter);
   await Elaborate.elaborate(linter);
+  await projectParser.stop();
+});
+test(`Testing definitions`, async () => {
   for (const character of [13, 14, 15]) {
     const definition = await findDefinitions(linter, Position.create(12, character));
     expect(definition).toHaveLength(1);
     expect(definition[0].targetUri.replace(__dirname, '')).toBe('file:///definition.vhd');
     expect(definition[0].targetRange.start.line).toBe(7);
     expect(definition[0].targetRange.end.line).toBe(7);
-    await projectParser.stop();
-
   }
+});
+test(`Testing empty definitions`, async () => {
+  const definition = await findDefinitions(linter, Position.create(16, 0));
+  expect(definition).toHaveLength(0);
+  const definition2 = await findDefinitions(linter, Position.create(6, 0));
+  expect(definition2).toHaveLength(0);
 });

--- a/test/unit_tests/definition/definition.test.ts
+++ b/test/unit_tests/definition/definition.test.ts
@@ -25,8 +25,19 @@ test(`Testing definitions`, async () => {
   }
 });
 test(`Testing empty definitions`, async () => {
-  const definition = await findDefinitions(linter, Position.create(16, 0));
+  const definition = await findDefinitions(linter, Position.create(24, 0));
   expect(definition).toHaveLength(0);
   const definition2 = await findDefinitions(linter, Position.create(6, 0));
   expect(definition2).toHaveLength(0);
+});
+test(`Testing definition for actual without formal`, async () => {
+  const definition = await findDefinitions(linter, Position.create(16, 9));
+  expect(definition).toHaveLength(1);
+  expect(definition[0].targetUri.replace(__dirname, '')).toBe('file:///definition.vhd');
+  expect(definition[0].targetRange.start.line).toBe(7);
+  expect(definition[0].targetRange.end.line).toBe(7);
+});
+test(`Testing definition for literal actual without formal`, async () => {
+  const definition = await findDefinitions(linter, Position.create(20, 7));
+  expect(definition).toHaveLength(0);
 });

--- a/test/unit_tests/definition/definition.test.ts
+++ b/test/unit_tests/definition/definition.test.ts
@@ -1,0 +1,19 @@
+import { test } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { Position } from 'vscode-languageserver';
+import { Elaborate } from '../../../lib/elaborate/elaborate';
+import { findDefinitions } from '../../../lib/languageFeatures/findDefinition';
+import { ProjectParser } from '../../../lib/project-parser';
+import { defaultSettingsGetter } from '../../../lib/settings';
+import { VhdlLinter } from '../../../lib/vhdl-linter';
+
+test(`Testing definitions`, async () => {
+  const projectParser = await ProjectParser.create([__dirname], '', defaultSettingsGetter);
+  const linter = new VhdlLinter('definition.vhd', readFileSync(__dirname + '/definition.vhd', { encoding: 'utf8' }),
+    projectParser, defaultSettingsGetter);
+  await Elaborate.elaborate(linter);
+  const definition = await findDefinitions(linter, Position.create(12, 14));
+  console.log(definition)
+  console.log(definition[0].text.split('\n').slice(definition[0].targetRange.start.line, definition[0].targetRange.end.line + 1));
+  await projectParser.stop();
+})

--- a/test/unit_tests/definition/definition.test.ts
+++ b/test/unit_tests/definition/definition.test.ts
@@ -1,4 +1,4 @@
-import { test } from '@jest/globals';
+import { expect, test } from '@jest/globals';
 import { readFileSync } from 'fs';
 import { Position } from 'vscode-languageserver';
 import { Elaborate } from '../../../lib/elaborate/elaborate';
@@ -12,8 +12,13 @@ test(`Testing definitions`, async () => {
   const linter = new VhdlLinter('definition.vhd', readFileSync(__dirname + '/definition.vhd', { encoding: 'utf8' }),
     projectParser, defaultSettingsGetter);
   await Elaborate.elaborate(linter);
-  const definition = await findDefinitions(linter, Position.create(12, 14));
-  console.log(definition)
-  console.log(definition[0].text.split('\n').slice(definition[0].targetRange.start.line, definition[0].targetRange.end.line + 1));
-  await projectParser.stop();
-})
+  for (const character of [13, 14, 15]) {
+    const definition = await findDefinitions(linter, Position.create(12, character));
+    expect(definition).toHaveLength(1);
+    expect(definition[0].targetUri.replace(__dirname, '')).toBe('file:///definition.vhd');
+    expect(definition[0].targetRange.start.line).toBe(7);
+    expect(definition[0].targetRange.end.line).toBe(7);
+    await projectParser.stop();
+
+  }
+});

--- a/test/unit_tests/definition/definition.vhd
+++ b/test/unit_tests/definition/definition.vhd
@@ -1,0 +1,16 @@
+
+library ieee;
+use ieee.std_logic_1164.all;
+entity bar is
+end entity;
+architecture arch of bar is
+
+  signal b : std_ulogic;
+
+begin
+  inst_foo : entity work.foo
+    port map(
+      i_a => b
+      );
+
+end arch;

--- a/test/unit_tests/definition/definition.vhd
+++ b/test/unit_tests/definition/definition.vhd
@@ -5,12 +5,12 @@ entity bar is
 end entity;
 architecture arch of bar is
 
-  signal b : std_ulogic;
+  signal bcd_unused : std_ulogic;
 
 begin
   inst_foo : entity work.foo
     port map(
-      i_a => b
+      i_a => bcd_unused
       );
 
 end arch;

--- a/test/unit_tests/definition/definition.vhd
+++ b/test/unit_tests/definition/definition.vhd
@@ -20,5 +20,10 @@ begin
     port map(
       5
       );
+       -- does not exist on purpose
+  inst_foo4 : entity work.does_not_exist
+    port map(
+      bcd_unused
+      );
 
 end arch;

--- a/test/unit_tests/definition/definition.vhd
+++ b/test/unit_tests/definition/definition.vhd
@@ -12,5 +12,13 @@ begin
     port map(
       i_a => bcd_unused
       );
+  inst_foo2 : entity work.foo
+    port map(
+      bcd_unused
+      );
+  inst_foo3 : entity work.foo_int
+    port map(
+      5
+      );
 
 end arch;

--- a/test/unit_tests/definition/helper.vhd
+++ b/test/unit_tests/definition/helper.vhd
@@ -1,0 +1,7 @@
+library ieee;
+use ieee.std_logic_1164.all;
+entity foo is
+  port (
+    i_a : out std_ulogic
+    );
+end entity;

--- a/test/unit_tests/definition/helper.vhd
+++ b/test/unit_tests/definition/helper.vhd
@@ -5,3 +5,8 @@ entity foo is
     i_a : out std_ulogic
     );
 end entity;
+entity foo_int is
+  port (
+    i_a : out integer
+    );
+end entity;


### PR DESCRIPTION
* Built a test case for find definition
* The initial character of the object was wrongly mapped to the previous object. (ie first character of signal reference)
* Tried to fix #198 but something else seems to have fixed it. v.1.4.3 installed via ext manager shows me 4 definitions for the test file. Test case and current version only one as expected.