### PR TITLE
Move definitions to a tracker object

### DIFF
--- a/lib/elaborate/elaborate.ts
+++ b/lib/elaborate/elaborate.ts
@@ -28,7 +28,7 @@ export class Elaborate {
         obj.aliasLinks = [];
       }
       if (implementsIHasDefinitions(obj)) {
-        obj.definitions = [];
+        obj.definitions.clear();
       }
       if (obj instanceof OEntity) {
         obj.correspondingArchitectures = [];

--- a/lib/elaborate/elaborate.ts
+++ b/lib/elaborate/elaborate.ts
@@ -16,10 +16,11 @@ export class Elaborate {
     this.file = vhdlLinter.file;
   }
   public static async elaborate(vhdlLinter: VhdlLinter) {
-
+    const now = Date.now();
     const elaborator = new Elaborate(vhdlLinter);
     await elaborator.elaborateAll();
     vhdlLinter.elaborated = true;
+    console.log(`elaborate ${vhdlLinter.file.uri.pathname} ${Date.now() - now}ms`);
   }
   public static clear(vhdlLinter: VhdlLinter) {
     for (const obj of vhdlLinter.file.objectList) {
@@ -46,7 +47,7 @@ export class Elaborate {
 
     await this.vhdlLinter.handleCanceled();
 
-    // const start = Date.now();
+    const start = Date.now();
     // Map architectures to entity
     for (const architecture of this.file.architectures) {
       if (architecture.entityName === undefined) {
@@ -65,6 +66,7 @@ export class Elaborate {
     for (const entity of this.file.entities) {
       entity.correspondingArchitectures = this.vhdlLinter.projectParser.architectures.filter(architecture => entity.lexerToken.getLText() === architecture.entityName.getLText());
     }
+    console.log(`elaborate A ${this.file.uri.pathname} ${Date.now() - start}ms`);
 
     // Map package body to package
     for (const pkg of this.file.packages) {
@@ -88,16 +90,23 @@ export class Elaborate {
 
       }
     }
+    console.log(`elaborate B ${this.file.uri.pathname} ${Date.now() - start}ms`);
 
     await this.vhdlLinter.handleCanceled();
     await ElaborateNames.elaborate(this.vhdlLinter);
+    console.log(`elaborate B1 ${this.file.uri.pathname} ${Date.now() - start}ms`);
+
     elaborateExpressionInstantiations(this.vhdlLinter.file);
+    console.log(`elaborate B2 ${this.file.uri.pathname} ${Date.now() - start}ms`);
     await this.vhdlLinter.handleCanceled();
     elaborateComponents(this.vhdlLinter);
+    console.log(`elaborate B3 ${this.file.uri.pathname} ${Date.now() - start}ms`);
     await this.vhdlLinter.handleCanceled();
     elaborateInstantiations(this.vhdlLinter);
+    console.log(`elaborate B4 ${this.file.uri.pathname} ${Date.now() - start}ms`);
     await this.vhdlLinter.handleCanceled();
     elaborateConfigurations(this.file, this.vhdlLinter.projectParser);
+    console.log(`elaborate C ${this.file.uri.pathname} ${Date.now() - start}ms`);
 
     await this.vhdlLinter.handleCanceled();
 
@@ -106,6 +115,7 @@ export class Elaborate {
     await this.vhdlLinter.handleCanceled();
     elaborateAliases(this.file);
     await this.vhdlLinter.handleCanceled();
+    console.log(`elaborate D ${this.file.uri.pathname} ${Date.now() - start}ms`);
 
   }
 

--- a/lib/elaborate/elaborateAliases.ts
+++ b/lib/elaborate/elaborateAliases.ts
@@ -6,8 +6,8 @@ export function elaborateAliases(file: OFile) {
     if (alias instanceof OAlias) {
       const lastName = alias.name[alias.name.length - 1];
       if (lastName) { // No Name is throwing an an error in parser but no fatal
-        alias.aliasDefinitions = lastName.definitions;
-        for (const read of lastName.definitions) {
+        alias.aliasDefinitions = lastName.definitions.get();
+        for (const read of lastName.definitions.get()) {
           if (implementsIHasNameLinks(read)) {
             read.aliasLinks.push(alias);
           }

--- a/lib/elaborate/elaborateAssociation.ts
+++ b/lib/elaborate/elaborateAssociation.ts
@@ -19,7 +19,7 @@ export function elaborateAssociations(file: O.OFile) {
           if (definition instanceof O.OAliasWithSignature) {
             elements = definition.typeMarks;
           } else if (definition instanceof O.OConfigurationDeclaration) {
-            elements = definition.definitions[0]?.ports ?? [];
+            elements = definition.definitions.get(0)?.ports ?? [];
           } else if (I.implementsIHasPorts(definition)) {
             elements = definition.ports;
           }
@@ -42,9 +42,9 @@ export function elaborateAssociations(file: O.OFile) {
       if (possibleFormals.length === 0) {
         continue;
       }
-      association.definitions.push(...possibleFormals);
+      association.definitions.add(file.uri, possibleFormals);
       for (const formalPart of association.formalPart) {
-        formalPart.definitions.push(...possibleFormals);
+        formalPart.definitions.add(file.uri, possibleFormals);
       }
       if (definitions.length === 1) {
         for (const possibleFormal of possibleFormals) {

--- a/lib/elaborate/elaborateComponents.ts
+++ b/lib/elaborate/elaborateComponents.ts
@@ -9,17 +9,17 @@ export function elaborateComponents(vhdlLinter: VhdlLinter) {
   for (const component of vhdlLinter.file.objectList) {
     if (component instanceof O.OComponent) {
       for (const entity of getEntities(component, vhdlLinter.projectParser)) {
-        component.definitions.push(entity);
+        component.definitions.add(vhdlLinter.file.uri, entity);
         entity.referenceComponents.push(component);
       }
       const entityPorts = component.definitions.flatMap(ent => ent.ports);
       for (const port of component.ports) {
-        port.definitions.push(...entityPorts.filter(p => p.lexerTokenEquals(port)));
+        port.definitions.add(vhdlLinter.file.uri, ...entityPorts.filter(p => p.lexerTokenEquals(port)));
         // TODO: create referenceLinks for the ports/generics of entities to the ports/generics of its component definitions
       }
       const entityGenerics = component.definitions.flatMap(ent => ent.generics);
       for (const generics of component.generics) {
-        generics.definitions.push(...entityGenerics.filter(g => g.lexerTokenEquals(generics)));
+        generics.definitions.add(vhdlLinter.file.uri, ...entityGenerics.filter(g => g.lexerTokenEquals(generics)));
       }
     }
   }

--- a/lib/elaborate/elaborateConfigurations.ts
+++ b/lib/elaborate/elaborateConfigurations.ts
@@ -5,8 +5,8 @@ export function elaborateConfigurations(file: OFile, projectParser: ProjectParse
   for (const configuration of file.objectList) {
     if (configuration instanceof OConfigurationDeclaration) {
       // find project entities
-      configuration.definitions.push(...projectParser.entities.filter(e => e.lexerToken.getLText() === configuration.entityName.getLText()));
-      for (const configurations of configuration.definitions) {
+      configuration.definitions.add(file.uri, projectParser.entities.filter(e => e.lexerToken.getLText() === configuration.entityName.getLText()));
+      for (const configurations of configuration.definitions.it()) {
         configurations.referenceConfigurations.push(configuration);
       }
     }

--- a/lib/elaborate/elaborateInstantiations.ts
+++ b/lib/elaborate/elaborateInstantiations.ts
@@ -7,28 +7,28 @@ export function elaborateInstantiations(vhdlLinter: VhdlLinter) {
       const defs = obj.instantiatedUnit.at(-1)!.definitions;
       switch (obj.type) {
       case 'entity':
-        obj.definitions = defs.filter(def => def instanceof O.OEntity) as O.OEntity[];
+        obj.definitions.set(obj.instantiatedUnit.at(-1)!.rootFile.uri, defs.filter(def => def instanceof O.OEntity) as O.OEntity[]);
         break;
       case 'component':
-        obj.definitions = defs.filter(def => def instanceof O.OComponent) as O.OComponent[];
+        obj.definitions.set(obj.instantiatedUnit.at(-1)!.rootFile.uri, defs.filter(def => def instanceof O.OComponent) as O.OComponent[]);
         break;
       case 'subprogram':
-        obj.definitions = defs.filter(def => def instanceof O.OSubprogram || def instanceof O.OAliasWithSignature) as (O.OSubprogram | O.OAliasWithSignature)[];
+        obj.definitions.set(obj.instantiatedUnit.at(-1)!.rootFile.uri, defs.filter(def => def instanceof O.OSubprogram || def instanceof O.OAliasWithSignature) as (O.OSubprogram | O.OAliasWithSignature)[]);
         break;
       case 'configuration':
-        obj.definitions = defs.filter(def => def instanceof O.OConfigurationDeclaration) as O.OConfigurationDeclaration[];
+        obj.definitions.set(obj.instantiatedUnit.at(-1)!.rootFile.uri, defs.filter(def => def instanceof O.OConfigurationDeclaration) as O.OConfigurationDeclaration[]);
         break;
       case 'unknown':
-        obj.definitions = defs.slice(0) as (typeof obj.definitions);
+        obj.definitions.set(obj.instantiatedUnit.at(-1)!.rootFile.uri, defs.get().slice(0) as ((O.OEntity | O.OSubprogram | O.OComponent | O.OAliasWithSignature | O.OConfigurationDeclaration)[]));
         break;
       }
-      for (const def of obj.definitions) {
+      for (const def of obj.definitions.it()) {
         def.nameLinks.push(obj);
       }
     } else if (obj instanceof O.OPackageInstantiation || obj instanceof O.OInterfacePackage) {
       const defs = obj.uninstantiatedPackage.at(-1)!.definitions;
-      obj.definitions = defs.filter(def => def instanceof O.OPackage) as O.OPackage[];
-      for (const def of obj.definitions) {
+      obj.definitions.set(obj.uninstantiatedPackage.at(-1)!.rootFile.uri, defs.filter(def => def instanceof O.OPackage) as O.OPackage[]);
+      for (const def of obj.definitions.it()) {
         def.nameLinks.push(obj.uninstantiatedPackage.at(-1)!);
       }
     }

--- a/lib/elaborate/elaborateNames.ts
+++ b/lib/elaborate/elaborateNames.ts
@@ -26,7 +26,10 @@ export class ElaborateNames {
     }
   }
   public static async elaborate(vhdlLinter: VhdlLinter) {
+    const start = Date.now();
     const elaborator = new ElaborateNames(vhdlLinter);
+    console.log(`elaborateNames A ${vhdlLinter.uri.pathname} ${Date.now() - start}ms`);
+
     // elaborate use clauses
     for (const obj of vhdlLinter.file.objectList) {
       await this.checkCancel(vhdlLinter);
@@ -34,13 +37,16 @@ export class ElaborateNames {
         elaborator.elaborateUseClauses(elaborator.getUseClauses(obj));
       }
     }
+    console.log(`elaborateNames B ${vhdlLinter.uri.pathname} ${Date.now() - start}ms`);
     elaborator.scopeVisibilityMap.clear();
     // elaborate ONames
     const nameList = (vhdlLinter.file.objectList.filter(obj => obj instanceof O.OName) as O.OName[]).sort((a, b) => a.nameToken.range.start.i - b.nameToken.range.start.i);
+    console.log(`elaborateNames C ${vhdlLinter.uri.pathname} ${Date.now() - start}ms`);
     for (const obj of nameList) {
       await this.checkCancel(vhdlLinter);
       elaborator.elaborate(obj);
     }
+    console.log(`elaborateNames D ${vhdlLinter.uri.pathname} ${Date.now() - start}ms`);
 
   }
   elaborate(name: O.OName) {

--- a/lib/languageFeatures/completion.ts
+++ b/lib/languageFeatures/completion.ts
@@ -14,7 +14,7 @@ function getSelectedNameCompletions(prefix: O.OName) {
   }[] = [];
   // if last prefix's definition is a record or protected type (i.e. its typeReferences contain a record or protected type)
   const prefixDefinitions = prefix.definitions.filter(I.implementsIHasSubTypeIndication);
-  const typeDefinitions = prefixDefinitions.flatMap(def => def.subtypeIndication.typeNames).flatMap(ref => ref.definitions);
+  const typeDefinitions = prefixDefinitions.flatMap(def => def.subtypeIndication.typeNames).flatMap(ref => ref.definitions.get());
   const recordTypes = typeDefinitions.filter(type => type instanceof O.ORecord) as O.ORecord[];
   result.push(...recordTypes.flatMap(type => type.children.map(child => ({
     label: child.lexerToken.text,
@@ -118,7 +118,7 @@ export function getCompletions(linter: VhdlLinter, position: Position): Completi
   const result = findParentInstantiation(linter, position);
   if (result) {
     const [instantiation, associationList] = result;
-    for (const definition of instantiation.definitions) {
+    for (const definition of instantiation.definitions.it()) {
       if (definition instanceof O.OAliasWithSignature || definition instanceof O.OConfigurationDeclaration) {
         // TODO Handle aliases and Configuration for completion
       } else {

--- a/lib/languageFeatures/findDefinition.ts
+++ b/lib/languageFeatures/findDefinition.ts
@@ -20,7 +20,7 @@ export function findDefinitions(linter: VhdlLinter, position: Position): ObjectB
       // The name of the entity and the configuration itself.
       // We need to add the actual definition of the token (not of the candidates, which only maybe is the same)
       if (candidate.entityName === token) {
-        definitions.add(...candidate.definitions);
+        definitions.add(...candidate.definitions.get());
       } else {
         definitions.add(candidate);
       }
@@ -28,10 +28,10 @@ export function findDefinitions(linter: VhdlLinter, position: Position): ObjectB
       // Only return definition of package instantiation if the call was not on the lexerToken itself
       if (candidate instanceof OPackageInstantiation) {
         if (candidate.lexerToken !== token) {
-          definitions.add(...candidate.definitions);
+          definitions.add(...candidate.definitions.get());
         }
       } else {
-        definitions.add(...candidate.definitions);
+        definitions.add(...candidate.definitions.get());
 
       }
     }

--- a/lib/languageFeatures/findReferencesHandler.ts
+++ b/lib/languageFeatures/findReferencesHandler.ts
@@ -61,7 +61,7 @@ export async function findReferenceAndDefinition(oldLinter: VhdlLinter, position
   }
   const compDefinitions = definitions.filter(def => def instanceof OComponent) as OComponent[];
   for (const component of compDefinitions) {
-    definitions.push(...component.definitions);
+    definitions.push(...component.definitions.get());
   }
 
   // find all tokens that are references to the definition

--- a/lib/languageFeatures/semanticToken.ts
+++ b/lib/languageFeatures/semanticToken.ts
@@ -35,7 +35,7 @@ function pushToken(buffer: BuilderParams[], range: O.OIRange, type: SemanticToke
 
 function findDefinition(obj: O.ObjectBase) {
   if (I.implementsIHasDefinitions(obj) && obj.definitions.length > 0) {
-    return obj.definitions[0];
+    return obj.definitions.get(0);
   }
 }
 

--- a/lib/languageFeatures/signatureHelp.ts
+++ b/lib/languageFeatures/signatureHelp.ts
@@ -10,7 +10,7 @@ export function signatureHelp(linter: VhdlLinter, position: Position): Signature
   }
   const [instantiation, associationList] = result;
   const signatures: SignatureInformation[] = [];
-  for (let definition of instantiation.definitions) {
+  for (let definition of instantiation.definitions.it()) {
     if (definition instanceof OAliasWithSignature) {
       // Handle AliasWIthSignatures
     } else {

--- a/lib/parser/definitionTracker.ts
+++ b/lib/parser/definitionTracker.ts
@@ -1,0 +1,63 @@
+import { ObjectBase } from "./objects";
+
+export class DefinitionTracker<T extends ObjectBase> {
+  private definitions = new Map<URL, T[]>();
+  set(url: URL, objects: T[]) {
+    this.definitions.set(url, objects);
+  }
+  add(url: URL, ...objects: (T[] | T)[]) {
+    const definitionsForUrl = this.definitions.get(url) ?? [];
+    //objects.flat() does not work for some reason
+    for (const object of objects) {
+      if (Array.isArray(object)) {
+        definitionsForUrl.push(...object);
+      } else {
+        definitionsForUrl.push(object);
+      }
+    }
+    this.definitions.set(url, definitionsForUrl);
+  }
+  *it() {
+    const def = this.definitions;
+    for (const definition of def.values()) {
+      yield* definition;
+    }
+  }
+  get(): T[]
+  get(index: number): T | undefined
+  get(index?: number) {
+    if (index !== undefined) {
+      return Array.from(this.it()).at(index);
+    }
+    return Array.from(this.it());
+  }
+  clear() {
+    this.definitions.clear();
+  }
+  some(predicate: (value: T, index: number, array: T[]) => boolean): boolean {
+    return this.get().some(predicate);
+  }
+  includes(searchElement: T, fromIndex?: number): boolean {
+    return this.get().includes(searchElement, fromIndex);
+  }
+  every(predicate: (value: T, index: number, array: T[]) => boolean): boolean {
+    return this.get().every(predicate);
+  }
+  flatMap<U, This = undefined>(callback: (this: This, value: T, index: number, array: T[]) => U | readonly U[]) {
+    return this.get().flatMap(callback);
+  }
+  map<U>(callbackfn: (value: T, index: number, array: T[]) => U) {
+    return this.get().map(callbackfn);
+  }
+  filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S): S[];
+  filter(predicate: (value: T, index: number, array: T[]) => unknown): T[];
+  filter(predicate: (value: T, index: number, array: T[]) => boolean) {
+    return this.get().filter(predicate);
+  }
+  find(predicate: (value: T, index: number, array: T[]) => boolean) {
+    return this.get().find(predicate);
+  }
+  get length() {
+    return this.get().length;
+  }
+}

--- a/lib/parser/interfaces.ts
+++ b/lib/parser/interfaces.ts
@@ -1,4 +1,5 @@
 import { OLexerToken } from "../lexer";
+import { DefinitionTracker } from "./definitionTracker";
 import * as O from './objects';
 export interface IHasLabel {
   label: OLexerToken;
@@ -78,7 +79,7 @@ export function implementsIHasNameLinks(obj: O.ObjectBase): obj is O.ObjectBase 
     && (obj as O.ObjectBase & Partial<IHasNameLinks>).aliasLinks !== undefined;
 }
 export interface IHasDefinitions {
-  definitions: O.ObjectBase[];
+  definitions: DefinitionTracker<O.ObjectBase>;
 }
 export function implementsIHasDefinitions(obj: O.ObjectBase): obj is O.ObjectBase & IHasDefinitions {
   return (obj as O.ObjectBase & Partial<IHasDefinitions>).definitions !== undefined;

--- a/lib/rules/ruleCodingStyle.ts
+++ b/lib/rules/ruleCodingStyle.ts
@@ -15,7 +15,7 @@ export class RuleCodingStyle extends RuleBase implements IRule {
     for (const instantiation of this.file.objectList) {
       if (instantiation instanceof OInstantiation) {
         if (instantiation.definitions.length === 1) { // In case of multiple definitions this check will not be run (maybe create separate rule)
-          const definition = instantiation.definitions[0];
+          const definition = instantiation.definitions.get(0);
           if (definition instanceof OEntity || definition instanceof OComponent || definition instanceof OConfigurationSpecification) {
             // Ignore subprograms as these normally have less parameters, and its harder to miss connections. (Which this rule tries to prevent)
             const portsOmitted = definition.ports.filter(port => {

--- a/lib/rules/ruleInstantiations.ts
+++ b/lib/rules/ruleInstantiations.ts
@@ -144,7 +144,7 @@ export class RuleInstantiation extends RuleBase implements IRule {
   check() {
     for (const instantiation of this.file.objectList) {
       if (instantiation instanceof O.OInstantiation) {
-        let definitions = instantiation.definitions;
+        let definitions = instantiation.definitions.get();
         if (instantiation.type === 'configuration') {
           definitions = definitions.flatMap((definition: O.OConfigurationDeclaration) => {
             const entities = this.vhdlLinter.projectParser.entities.filter(e => e.lexerToken.getLText() === definition.entityName.getLText());

--- a/lib/rules/ruleNotDeclared.ts
+++ b/lib/rules/ruleNotDeclared.ts
@@ -107,7 +107,7 @@ export class RuleNotDeclared extends RuleBase implements IRule {
     const possibleMatches: (O.ODeclaration|O.ORecordChild)[] = [];
     if (ref instanceof O.OSelectedName) {
       const defs = ref.prefixTokens.at(-1)!.definitions.filter(def => I.implementsIHasSubTypeIndication(def)) as (O.ObjectBase & I.IHasSubtypeIndication)[];
-      for (const typeDef of defs.flatMap(def => def.subtypeIndication.typeNames).flatMap(name => name.definitions)) {
+      for (const typeDef of defs.flatMap(def => def.subtypeIndication.typeNames).flatMap(name => name.definitions.get())) {
         if (I.implementsIHasDeclarations(typeDef)) {
           possibleMatches.push(...typeDef.declarations);
         }

--- a/lib/rules/ruleTypeResolved.ts
+++ b/lib/rules/ruleTypeResolved.ts
@@ -13,7 +13,7 @@ export class RuleTypeResolved extends RuleBase implements IRule {
       const type = object.subtypeIndication.typeNames[0];
       if (type) {
 
-        const definition = type?.definitions[0];
+        const definition = type?.definitions.get(0);
         if (definition instanceof O.OSubType && definition.subtypeIndication.resolutionIndication.length > 0) {
           let unresolvedTypes: string[] = [];
           const lastTypeName = definition.subtypeIndication.typeNames.at(-1);
@@ -63,7 +63,7 @@ export class RuleTypeResolved extends RuleBase implements IRule {
       || object instanceof O.ORecordChild && this.settings.style.preferredLogicTypeRecordChild === 'resolved') {
       const type = object.subtypeIndication.typeNames[0];
       if (type) {
-        let definition = type.definitions[0];
+        let definition = type.definitions.get(0);
         if (definition) {
           // For aliases check find the aliased type
           const alias = [type.nameToken.getLText()];

--- a/lib/rules/ruleUnused.ts
+++ b/lib/rules/ruleUnused.ts
@@ -43,7 +43,7 @@ export class RuleUnused extends RuleBase implements IRule {
       return;
     }
     for (const port of obj.ports) {
-      const type = port.subtypeIndication.typeNames[0]?.definitions?.[0];
+      const type = port.subtypeIndication.typeNames[0]?.definitions?.get(0);
       // Ignore ports of protected types as they are assumed to have side-effects so will not be read/written
       if ((type instanceof OType && (type.protected || type.protectedBody))) {
         continue;
@@ -108,7 +108,7 @@ export class RuleUnused extends RuleBase implements IRule {
               this.addUnusedMessage(declaration, `Not reading ${typeName} '${declaration.lexerToken.text}'`);
             } else if (writes.length === 0) {
               // Assume protected type has side-effect and does not net writing to.
-              const type = declaration.subtypeIndication.typeNames[0]?.definitions?.[0];
+              const type = declaration.subtypeIndication.typeNames[0]?.definitions?.get(0);
               if ((type instanceof OType && (type.protected || type.protectedBody)) === false) {
                 this.addUnusedMessage(declaration, `Not writing ${typeName} '${declaration.lexerToken.text}'`);
               }

--- a/test/integrationTests/memoryLeak/memoryLeak.test.ts
+++ b/test/integrationTests/memoryLeak/memoryLeak.test.ts
@@ -18,7 +18,7 @@ test('testing multi elaborate for memory leak', async () => {
 
     expect(linter.file.entities[0]?.contextReferences[0]?.names.at(-1)?.definitions.length).toBe(1);
 
-    const context = linter.file.entities[0]?.contextReferences[0]?.names.at(-1)?.definitions[0] as OContext;
+    const context = linter.file.entities[0]?.contextReferences[0]?.names.at(-1)?.definitions.get(0) as OContext;
     const useClauseDefinitions = context.useClauses.find(useClause => useClause.names[1]?.nameToken.getLText() === 'pkg')?.names.at(-1)?.definitions;
     expect(useClauseDefinitions).toHaveLength(1);
 

--- a/test/unitTests/selectedNameDefinitions/selectedName.test.ts
+++ b/test/unitTests/selectedNameDefinitions/selectedName.test.ts
@@ -27,15 +27,15 @@ test.each([
   const assignment = linter.file.architectures[0]?.statements[0] as OAssignment;
   expect(assignment.names).toHaveLength(4);
   expect(assignment.names[3]).toBeInstanceOf(OSelectedName);
-  expect(assignment.names[3]?.definitions).toHaveLength(1);
-  expect(assignment.names[3]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[3]?.definitions[0]?.lexerToken?.getLText()).toBe('apple');
+  expect(assignment.names[3]?.definitions.get()).toHaveLength(1);
+  expect(assignment.names[3]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[3]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('apple');
 
   expect(assignment.names[0]?.write).toBe(true);
   expect(assignment.names[1]).toBeInstanceOf(OSelectedName);
-  expect(assignment.names[1]?.definitions).toHaveLength(1);
-  expect(assignment.names[1]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[1]?.definitions[0]?.lexerToken?.getLText()).toBe('banana');
+  expect(assignment.names[1]?.definitions.get()).toHaveLength(1);
+  expect(assignment.names[1]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[1]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('banana');
 });
 
 test.each([
@@ -48,16 +48,16 @@ test.each([
 
   const call = linter.file.architectures[0]?.statements[0] as OInstantiation;
   expect(call.definitions).toHaveLength(1);
-  expect(call.definitions[0]).toBeInstanceOf(OSubprogram);
-  expect(call.definitions[0]?.lexerToken?.getLText()).toBe('apple');
+  expect(call.definitions.get()[0]).toBeInstanceOf(OSubprogram);
+  expect(call.definitions.get()[0]?.lexerToken?.getLText()).toBe('apple');
 
   expect(call.portAssociationList?.children).toHaveLength(1);
   expect(call.portAssociationList?.children[0]?.actualIfInput).toHaveLength(2);
   expect(call.portAssociationList?.children[0]?.actualIfInput[1]).toBeInstanceOf(OSelectedName);
   expect(call.portAssociationList?.children[0]?.actualIfInput[1]).toBeInstanceOf(OSelectedName);
-  expect(call.portAssociationList?.children[0]?.actualIfInput[1]?.definitions).toHaveLength(1);
-  expect(call.portAssociationList?.children[0]?.actualIfInput[1]?.definitions[0]).toBeInstanceOf(OSubprogram);
-  expect(call.portAssociationList?.children[0]?.actualIfInput[1]?.definitions[0]?.lexerToken?.getLText()).toBe('banana');
+  expect(call.portAssociationList?.children[0]?.actualIfInput[1]?.definitions.get()).toHaveLength(1);
+  expect(call.portAssociationList?.children[0]?.actualIfInput[1]?.definitions.get()[0]).toBeInstanceOf(OSubprogram);
+  expect(call.portAssociationList?.children[0]?.actualIfInput[1]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('banana');
 
 
   expect(linter.messages).toEqual(expect.arrayContaining([
@@ -103,19 +103,19 @@ test.each([
   expect(assignment.names).toHaveLength(5);
   expect(assignment.names[3]).toBeInstanceOf(OSelectedName);
   expect(assignment.names[3]?.definitions).toHaveLength(1);
-  expect(assignment.names[3]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[3]?.definitions[0]?.lexerToken?.getLText()).toBe('banana');
+  expect(assignment.names[3]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[3]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('banana');
   expect(assignment.names[4]).toBeInstanceOf(OSelectedName);
   expect(assignment.names[4]?.definitions).toHaveLength(1);
-  expect(assignment.names[4]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[4]?.definitions[0]?.lexerToken?.getLText()).toBe('apple');
+  expect(assignment.names[4]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[4]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('apple');
 
   expect(assignment.names[0]?.write).toBe(true);
-  expect(assignment.names[0]?.definitions[0]?.lexerToken?.getLText()).toBe('s1');
+  expect(assignment.names[0]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('s1');
   expect(assignment.names[1]).toBeInstanceOf(OSelectedName);
   expect(assignment.names[1]?.definitions).toHaveLength(1);
-  expect(assignment.names[1]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[1]?.definitions[0]?.lexerToken?.getLText()).toBe('apple');
+  expect(assignment.names[1]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[1]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('apple');
 });
 
 test.each([
@@ -129,11 +129,11 @@ test.each([
   expect(assignment.names).toHaveLength(4);
   expect(assignment.names[3]).toBeInstanceOf(OSelectedName);
   expect(assignment.names[3]?.definitions).toHaveLength(1);
-  expect(assignment.names[3]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[3]?.definitions[0]?.lexerToken?.getLText()).toBe('apple');
+  expect(assignment.names[3]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[3]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('apple');
 
   expect(assignment.names[1]).toBeInstanceOf(OSelectedName);
   expect(assignment.names[1]?.definitions).toHaveLength(1);
-  expect(assignment.names[1]?.definitions[0]).toBeInstanceOf(ORecordChild);
-  expect(assignment.names[1]?.definitions[0]?.lexerToken?.getLText()).toBe('banana');
+  expect(assignment.names[1]?.definitions.get()[0]).toBeInstanceOf(ORecordChild);
+  expect(assignment.names[1]?.definitions.get()[0]?.lexerToken?.getLText()).toBe('banana');
 });


### PR DESCRIPTION
The idea is to keep track about which definitions comes from which file, to be better to replace with changing files and avoid the memory leak situation.