### PR TITLE
Fix race condition leading to broken semantic tokens

### DIFF
--- a/lib/languageServer.ts
+++ b/lib/languageServer.ts
@@ -202,7 +202,8 @@ const linterManager = new LinterManager();
 async function validateTextDocument(textDocument: TextDocument, fromProjectParser = false) {
   try {
     if (projectParser !== undefined) {
-      const vhdlLinter = await linterManager.triggerRefresh(textDocument.uri, textDocument.getText(), projectParser, getDocumentSettings, fromProjectParser);
+
+      const vhdlLinter = await linterManager.triggerRefresh(textDocument.uri, textDocument.getText(), projectParser, getDocumentSettings, textDocument.version, fromProjectParser);
       const diagnostics = await vhdlLinter.checkAll();
       diagnostics.forEach((diag) => diag.source = 'vhdl-linter');
       await connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });

--- a/lib/languageServer.ts
+++ b/lib/languageServer.ts
@@ -179,6 +179,7 @@ export const initialization = new Promise<void>(resolve => {
             });
           }
         }
+        void connection.sendRequest('workspace/semanticTokens/refresh');
       });
       documents.onDidChangeContent(change => {
         void validateTextDocument(change.document);

--- a/lib/linterManager.ts
+++ b/lib/linterManager.ts
@@ -92,18 +92,20 @@ export class LinterManager {
       }
       state.valid = false;
     } else {
-      for (const cachedFile of projectParser.cachedFiles) {
-        if (cachedFile instanceof FileCacheVhdl) {
-          for (const obj of cachedFile.linter.file.objectList) {
-            if (implementsIHasDefinitions(obj)) {
-              obj.definitions = [];
-            }
-            if (implementsIHasNameLinks(obj)) {
-              obj.nameLinks = [];
-              obj.aliasLinks = [];
-            }
-            if (obj instanceof OAlias) {
-              obj.aliasDefinitions = [];
+      if (fromProjectParser === false) {
+        for (const cachedFile of projectParser.cachedFiles) {
+          if (cachedFile instanceof FileCacheVhdl) {
+            for (const obj of cachedFile.linter.file.objectList) {
+              if (implementsIHasDefinitions(obj)) {
+                obj.definitions = [];
+              }
+              if (implementsIHasNameLinks(obj)) {
+                obj.nameLinks = [];
+                obj.aliasLinks = [];
+              }
+              if (obj instanceof OAlias) {
+                obj.aliasDefinitions = [];
+              }
             }
           }
         }

--- a/lib/projectParser.ts
+++ b/lib/projectParser.ts
@@ -9,8 +9,7 @@ import { CancellationToken, Diagnostic, DiagnosticSeverity, WorkDoneProgressRepo
 import { Elaborate } from './elaborate/elaborate';
 import { elaborateTargetLibrary } from './elaborate/elaborateTargetLibrary';
 import { SetAdd } from './languageFeatures/findReferencesHandler';
-import { implementsIHasDefinitions, implementsIHasNameLinks } from './parser/interfaces';
-import { OAlias, OArchitecture, OConfigurationDeclaration, OContext, OEntity, OPackage, OPackageInstantiation } from './parser/objects';
+import { OArchitecture, OConfigurationDeclaration, OContext, OEntity, OPackage, OPackageInstantiation } from './parser/objects';
 import { VerilogParser } from './verilogParser';
 import { SettingsGetter, VhdlLinter } from './vhdlLinter';
 
@@ -99,22 +98,7 @@ export class ProjectParser {
       });
       watcher.on('change', (path) => {
         const handleEvent = async () => {
-          for (const cachedFile of this.cachedFiles) {
-            if (cachedFile instanceof FileCacheVhdl) {
-              for (const obj of cachedFile.linter.file.objectList) {
-                if (implementsIHasDefinitions(obj)) {
-                  obj.definitions = [];
-                }
-                if (implementsIHasNameLinks(obj)) {
-                  obj.nameLinks = [];
-                  obj.aliasLinks = [];
-                }
-                if (obj instanceof OAlias) {
-                  obj.aliasDefinitions = [];
-                }
-              }
-            }
-          }
+
           const url = pathToFileURL(path);
 
           const cachedFile = process.platform === 'win32'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
 				"chokidar": "^3.5.3",
 				"minimatch": "^9.0.2",
 				"string-similarity": "^3.0.0",
-				"vscode-languageclient": "^8.0.2",
-				"vscode-languageserver": "^8.0.2",
+				"vscode-languageclient": "^8.1.0",
+				"vscode-languageserver": "^8.1.0",
 				"vscode-languageserver-textdocument": "^1.0.7"
 			},
 			"devDependencies": {
@@ -2644,7 +2644,8 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -7596,44 +7597,35 @@
 			}
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+			"integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+			"integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
 			"dependencies": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.2"
+				"minimatch": "^5.1.0",
+				"semver": "^7.3.7",
+				"vscode-languageserver-protocol": "3.17.3"
 			},
 			"engines": {
 				"vscode": "^1.67.0"
 			}
 		},
-		"node_modules/vscode-languageclient/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/vscode-languageclient/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=10"
 			}
 		},
 		"node_modules/vscode-languageclient/node_modules/semver": {
@@ -7651,23 +7643,23 @@
 			}
 		},
 		"node_modules/vscode-languageserver": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
-			"integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+			"integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
 			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.2"
+				"vscode-languageserver-protocol": "3.17.3"
 			},
 			"bin": {
 				"installServerIntoExtension": "bin/installServerIntoExtension"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+			"integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
 			"dependencies": {
-				"vscode-jsonrpc": "8.0.2",
-				"vscode-languageserver-types": "3.17.2"
+				"vscode-jsonrpc": "8.1.0",
+				"vscode-languageserver-types": "3.17.3"
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
@@ -7676,9 +7668,9 @@
 			"integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg=="
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+			"integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
 		},
 		"node_modules/vscode-oniguruma": {
 			"version": "1.7.0",
@@ -9860,7 +9852,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "2.0.0",
@@ -13468,35 +13461,26 @@
 			}
 		},
 		"vscode-jsonrpc": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+			"integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
 		},
 		"vscode-languageclient": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+			"integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
 			"requires": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.2"
+				"minimatch": "^5.1.0",
+				"semver": "^7.3.7",
+				"vscode-languageserver-protocol": "3.17.3"
 			},
 			"dependencies": {
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
 				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "^2.0.1"
 					}
 				},
 				"semver": {
@@ -13510,20 +13494,20 @@
 			}
 		},
 		"vscode-languageserver": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
-			"integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+			"integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
 			"requires": {
-				"vscode-languageserver-protocol": "3.17.2"
+				"vscode-languageserver-protocol": "3.17.3"
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+			"integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
 			"requires": {
-				"vscode-jsonrpc": "8.0.2",
-				"vscode-languageserver-types": "3.17.2"
+				"vscode-jsonrpc": "8.1.0",
+				"vscode-languageserver-types": "3.17.3"
 			}
 		},
 		"vscode-languageserver-textdocument": {
@@ -13532,9 +13516,9 @@
 			"integrity": "sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg=="
 		},
 		"vscode-languageserver-types": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+			"integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
 		},
 		"vscode-oniguruma": {
 			"version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -566,8 +566,8 @@
 		"chokidar": "^3.5.3",
 		"minimatch": "^9.0.2",
 		"string-similarity": "^3.0.0",
-		"vscode-languageclient": "^8.0.2",
-		"vscode-languageserver": "^8.0.2",
+		"vscode-languageclient": "^8.1.0",
+		"vscode-languageserver": "^8.1.0",
 		"vscode-languageserver-textdocument": "^1.0.7"
 	},
 	"enhancedScopes": [

--- a/test/integrationTests/fileAdding/testfiles/test_entity.sv
+++ b/test/integrationTests/fileAdding/testfiles/test_entity.sv
@@ -1,3 +1,0 @@
-
-      module test_enttity
-      endmodule;

--- a/test/integrationTests/memoryLeak/randomAccess/randomTest.ts
+++ b/test/integrationTests/memoryLeak/randomAccess/randomTest.ts
@@ -32,13 +32,14 @@ export async function randomTest(directory: string) {
     }, 0)).reduce((prev, a) => prev + a, 0);
     return definitions;
   }
+  let version = 0;
   async function triggerRefresh(filename: string) {
     const url = pathToFileURL(join(directory, filename));
     // (projectParser.watchers is private)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
     (projectParser as any).watchers[0].emit('change', join(directory, filename));
     const text = readFileSyncNorm(url, { encoding: 'utf8' });
-    const linter = await linterManager.triggerRefresh(url.toString(), text, projectParser, defaultSettingsGetter);
+    const linter = await linterManager.triggerRefresh(url.toString(), text, projectParser, defaultSettingsGetter, version++);
     await linter.checkAll();
   }
   const files = readdirSync(directory).filter(filename => filename.match(/\.vhd$/i));

--- a/test/unitTests/linterManager/linterManager.test.ts
+++ b/test/unitTests/linterManager/linterManager.test.ts
@@ -135,7 +135,6 @@ test('Running linterManager cancel getLinter', async () => {
   // Trigger 3 times, to simulate race condition.
   // The first two times elaborate is delayed so the third call which is not delayed shall correctly cancel the first two ones.
   const projectParser = await ProjectParser.create([], defaultSettingsGetter);
-  console.log('projectParser', projectParser);
   const linterManager = new LinterManager();
   const uri = pathToFileURL(__filename).toString();
   const cancellationTokenSources = new CancellationTokenSource();


### PR DESCRIPTION
Testing around #420.
I moved the clear of definitions to linter manager. This is no done only in case parsing (!= elaboration) was successful.
The outdated result should be kept.

To combat race condition lintermanager now gets the version number from the LSP to validate that it is running on the newest "version" of the file.
@Nik-Sch Can you please test during usage of vhdl-linter