### PR TITLE
Fix project parser file change handling on windows

### DIFF
--- a/lib/projectParser.ts
+++ b/lib/projectParser.ts
@@ -102,7 +102,7 @@ export class ProjectParser {
           const url = pathToFileURL(path);
 
           const cachedFile = process.platform === 'win32'
-            ? this.cachedFiles.find(cachedFile => cachedFile.uri.toString() === url.toString().toLowerCase())
+            ? this.cachedFiles.find(cachedFile => cachedFile.uri.toString().toLowerCase() === url.toString().toLowerCase())
             : this.cachedFiles.find(cachedFile => cachedFile.uri.toString() === url.toString());
           if (cachedFile) {
             await cachedFile.parse();
@@ -119,7 +119,7 @@ export class ProjectParser {
         const url = pathToFileURL(path);
 
         const cachedFileIndex = process.platform === 'win32'
-          ? this.cachedFiles.findIndex(cachedFile => cachedFile.uri.toString() === url.toString().toLowerCase())
+          ? this.cachedFiles.findIndex(cachedFile => cachedFile.uri.toString().toLowerCase() === url.toString().toLowerCase())
           : this.cachedFiles.findIndex(cachedFile => cachedFile.uri.toString() === url.toString());
         if (cachedFileIndex > -1) {
           this.cachedFiles.splice(cachedFileIndex, 1);

--- a/test/integrationTests/fileRemoving/fileRemoving.test.ts
+++ b/test/integrationTests/fileRemoving/fileRemoving.test.ts
@@ -38,7 +38,8 @@ test('testing removing of vhdl files', async () => {
 
   const projectParser = await ProjectParser.create([pathToFileURL(__dirname)], defaultSettingsGetter);
 
-  expect(projectParser.entities.find(entity => entity.lexerToken.getLText() === 'test_entity')).toBeDefined();
+  expect(projectParser.entities.filter(entity => entity.lexerToken.getLText() === 'test_entity')).toHaveLength(1);
+
   await Promise.all([
     (async () => {
       await wait(100);
@@ -47,8 +48,8 @@ test('testing removing of vhdl files', async () => {
     })(),
     new Promise(resolve => projectParser.events.once('change', resolve))
   ]);
+  expect(projectParser.entities.filter(entity => entity.lexerToken.getLText() === 'test_entity')).toHaveLength(0);
 
-  expect(projectParser.entities.find(entity => entity.lexerToken.getLText() === 'test_entity')).toBeUndefined();
   await projectParser.stop();
 });
 test('testing removing of verilog files', async () => {


### PR DESCRIPTION
It was completely busted for files containing upper case letters... 
Btw win and mac tests were not required before, I added them to the list of required tests.