### PR TITLE
Fix debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "vhdl-linter",
 	"publisher": "g0t00",
+	"version": "0.0.1",
 	"main": "./dist/lib/vscode.js",
 	"description": "A typescript based linter for vhdl",
 	"keywords": [],


### PR DESCRIPTION
For the plugin debug to work the package.json needs to have a version number (the actual value does not matter). Otherwise vscode extension host does not load the plugin.
I am 90% sure this does not break the release workflow. @Nik-Sch Maybe make sure?