### PR TITLE
Ignore unused iterators

### DIFF
--- a/lib/rules/ruleUnused.ts
+++ b/lib/rules/ruleUnused.ts
@@ -1,7 +1,7 @@
 import { DiagnosticSeverity } from "vscode-languageserver";
 import { IHasLexerToken, IHasNameToken, IHasPorts, implementsIHasDeclarations, implementsIHasGenerics, implementsIHasLexerToken, implementsIHasPorts } from "../parser/interfaces";
-import { ObjectBase, OComponent, OConstant, OEntity, OFile, OPackage, OPackageBody, OPackageInstantiation, OSignal, OSubprogram, OType, OVariable } from "../parser/objects";
-import { codeActionFromPrefixSuffix, IRule, RuleBase } from "./rulesBase";
+import { OComponent, OConstant, OEntity, OFile, OForGenerate, OForLoop, OPackage, OPackageBody, OPackageInstantiation, OSignal, OSubprogram, OType, OVariable, ObjectBase } from "../parser/objects";
+import { IRule, RuleBase, codeActionFromPrefixSuffix } from "./rulesBase";
 
 export class RuleUnused extends RuleBase implements IRule {
   public static readonly ruleName = 'unused';
@@ -18,6 +18,10 @@ export class RuleUnused extends RuleBase implements IRule {
     }
     // ignore entities that do not have the architecture in the same file
     if (obj.parent instanceof OEntity && obj.rootFile.architectures.find(a => a.entityName.getLText() === (obj.parent as OEntity).lexerToken.getLText()) === undefined) {
+      return;
+    }
+    // ignore unused iterators
+    if ((obj.parent instanceof OForLoop || obj.parent instanceof OForGenerate) && obj.parent.declarations[0] === obj) {
       return;
     }
     const token = implementsIHasLexerToken(obj) ? obj.lexerToken : obj.nameToken;

--- a/test/test_files/test_no_error/unused/unused_for.vhd
+++ b/test/test_files/test_no_error/unused/unused_for.vhd
@@ -9,7 +9,7 @@ begin
     end loop;
     wait;
   end process;
-  label_x : for I in range generate
+  label_x : for I in 1 to 10 generate
 
   end generate;
 end architecture;

--- a/test/test_files/test_no_error/unused/unused_for.vhd
+++ b/test/test_files/test_no_error/unused/unused_for.vhd
@@ -1,0 +1,15 @@
+entity unused_for is
+end entity;
+architecture arch of unused_for is
+begin
+  process is
+  begin
+    for I in 1 to 10 loop
+      report "hello world";
+    end loop;
+    wait;
+  end process;
+  label_x : for I in range generate
+
+  end generate;
+end architecture;

--- a/test/test_files/test_no_error/unused/unused_for.vhd
+++ b/test/test_files/test_no_error/unused/unused_for.vhd
@@ -4,7 +4,7 @@ architecture arch of unused_for is
 begin
   process is
   begin
-    for I in 1 to 10 loop
+    for I in 1 to 10 loop -- unused iterator constant should not generate an unused warning
       report "hello world";
     end loop;
     wait;


### PR DESCRIPTION
As the iterators are mandatory I think it is not useful to complain about them when they are unused.
At least for regular for loops (As the content can have side effects and then the iterator value does not matter)