### PR TITLE
Project parser clear elaboration on re-elaborate.  (Memoryleak)

### DIFF
--- a/lib/languageServer.ts
+++ b/lib/languageServer.ts
@@ -146,7 +146,6 @@ export const initialization = new Promise<void>(resolve => {
         uris.push(uri);
         clearTimeout(timeout);
         timeout = setTimeout(() => {
-          uris = [];
           // A file in project parser got changed
           // Revalidate all *other* files. (The file itself gets directly handled.)
           for (const document of documents.all()) {
@@ -154,6 +153,7 @@ export const initialization = new Promise<void>(resolve => {
               void validateTextDocument(document, true);
             }
           }
+          uris = [];
           for (const cache of projectParser.cachedFiles) {
             if (cache instanceof FileCacheLibraryList) {
               cache.messages.forEach((diag) => diag.source = 'vhdl-linter');

--- a/lib/linterManager.ts
+++ b/lib/linterManager.ts
@@ -16,7 +16,7 @@ interface ILinterState {
   version: number
 }
 export class LinterManager {
-  constructor(public connection?: _Connection) {}
+  constructor(public connection?: _Connection) { }
   private projectParserDebounce: Record<string, NodeJS.Timeout> = {};
   // We do not actually care for the linter where the parsing failed.
   // So this will always point to working linter
@@ -93,20 +93,18 @@ export class LinterManager {
       }
       state.valid = false;
     } else {
-      if (fromProjectParser === false) {
-        for (const cachedFile of projectParser.cachedFiles) {
-          if (cachedFile instanceof FileCacheVhdl) {
-            for (const obj of cachedFile.linter.file.objectList) {
-              if (implementsIHasDefinitions(obj)) {
-                obj.definitions = [];
-              }
-              if (implementsIHasNameLinks(obj)) {
-                obj.nameLinks = [];
-                obj.aliasLinks = [];
-              }
-              if (obj instanceof OAlias) {
-                obj.aliasDefinitions = [];
-              }
+      for (const cachedFile of projectParser.cachedFiles) {
+        if (cachedFile instanceof FileCacheVhdl) {
+          for (const obj of cachedFile.linter.file.objectList) {
+            if (implementsIHasDefinitions(obj)) {
+              obj.definitions = [];
+            }
+            if (implementsIHasNameLinks(obj)) {
+              obj.nameLinks = [];
+              obj.aliasLinks = [];
+            }
+            if (obj instanceof OAlias) {
+              obj.aliasDefinitions = [];
             }
           }
         }

--- a/lib/linterManager.ts
+++ b/lib/linterManager.ts
@@ -3,8 +3,6 @@ import { EventEmitter } from "stream";
 import { CancellationToken, CancellationTokenSource, LSPErrorCodes, ResponseError, _Connection } from "vscode-languageserver";
 import { Elaborate } from "./elaborate/elaborate";
 import { normalizeUri } from "./normalizeUri";
-import { implementsIHasDefinitions, implementsIHasNameLinks } from "./parser/interfaces";
-import { OAlias } from "./parser/objects";
 import { FileCacheVhdl, ProjectParser } from "./projectParser";
 import { VhdlLinter } from "./vhdlLinter";
 
@@ -95,18 +93,7 @@ export class LinterManager {
     } else {
       for (const cachedFile of projectParser.cachedFiles) {
         if (cachedFile instanceof FileCacheVhdl) {
-          for (const obj of cachedFile.linter.file.objectList) {
-            if (implementsIHasDefinitions(obj)) {
-              obj.definitions = [];
-            }
-            if (implementsIHasNameLinks(obj)) {
-              obj.nameLinks = [];
-              obj.aliasLinks = [];
-            }
-            if (obj instanceof OAlias) {
-              obj.aliasDefinitions = [];
-            }
-          }
+          Elaborate.clear(cachedFile.linter);
         }
       }
       // Parser success run elaboration


### PR DESCRIPTION
On save of a file, all open files get re-elaborated.
When doing this, the files did not get cleared and did accumulate more and more definitions.

Also on saving a file it got double-elaborated. (On change and on save). There was a erronous handling for this.