### PR TITLE
add proper error reporting to vhdl-linter.yml files

### DIFF
--- a/lib/projectParser.ts
+++ b/lib/projectParser.ts
@@ -433,7 +433,7 @@ export class FileCacheSettings {
       this.settings = parsed;
     } else {
       this.messages.push({
-        message: `This yaml does not match the schema for our settings: ${validate.errors?.map(e => this.yamlSchemaErrorToString(e)).join('\n') ?? 'unknown error'}`,
+        message: `This yaml does not match the schema for vhdl-linter settings: ${validate.errors?.map(e => this.yamlSchemaErrorToString(e)).join('\n') ?? 'unknown error'}`,
         range: { start: { line: 0, character: 0 }, end: { line: 0, character: 50 } },
         severity: DiagnosticSeverity.Error
       });

--- a/test/unitTests/fileSettings/__snapshots__/fileSettings.test.ts.snap
+++ b/test/unitTests/fileSettings/__snapshots__/fileSettings.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`invalid yaml invalid0.vhdl-linter.yml 1`] = `
 [
   {
-    "message": "This yaml does not match the schema for our settings: Properties key-not-allowed are not allowed!",
+    "message": "This yaml does not match the schema for vhdl-linter settings: Properties key-not-allowed are not allowed!",
     "range": {
       "end": {
         "character": 50,
@@ -22,7 +22,7 @@ exports[`invalid yaml invalid0.vhdl-linter.yml 1`] = `
 exports[`invalid yaml invalid1.vhdl-linter.yml 1`] = `
 [
   {
-    "message": "This yaml does not match the schema for our settings: /trace/server: must be equal to one of the allowed values (off,messages,verbose)",
+    "message": "This yaml does not match the schema for vhdl-linter settings: /trace/server: must be equal to one of the allowed values (off,messages,verbose)",
     "range": {
       "end": {
         "character": 50,
@@ -41,7 +41,7 @@ exports[`invalid yaml invalid1.vhdl-linter.yml 1`] = `
 exports[`invalid yaml invalid2.vhdl-linter.yml 1`] = `
 [
   {
-    "message": "This yaml does not match the schema for our settings: /trace/server: must be string (string)",
+    "message": "This yaml does not match the schema for vhdl-linter settings: /trace/server: must be string (string)",
     "range": {
       "end": {
         "character": 50,
@@ -60,7 +60,7 @@ exports[`invalid yaml invalid2.vhdl-linter.yml 1`] = `
 exports[`invalid yaml invalid3.vhdl-linter.yml 1`] = `
 [
   {
-    "message": "This yaml does not match the schema for our settings: /paths/additional: must be array (array)",
+    "message": "This yaml does not match the schema for vhdl-linter settings: /paths/additional: must be array (array)",
     "range": {
       "end": {
         "character": 50,
@@ -79,7 +79,7 @@ exports[`invalid yaml invalid3.vhdl-linter.yml 1`] = `
 exports[`invalid yaml invalid4.vhdl-linter.yml 1`] = `
 [
   {
-    "message": "This yaml does not match the schema for our settings: /paths/additional/1: must be string (string)",
+    "message": "This yaml does not match the schema for vhdl-linter settings: /paths/additional/1: must be string (string)",
     "range": {
       "end": {
         "character": 50,
@@ -98,7 +98,7 @@ exports[`invalid yaml invalid4.vhdl-linter.yml 1`] = `
 exports[`invalid yaml invalid5.vhdl-linter.yml 1`] = `
 [
   {
-    "message": "This yaml does not match the schema for our settings: /analysis/conditionalAnalysis/banana: must be string (string)",
+    "message": "This yaml does not match the schema for vhdl-linter settings: /analysis/conditionalAnalysis/banana: must be string (string)",
     "range": {
       "end": {
         "character": 50,

--- a/test/unitTests/fileSettings/__snapshots__/fileSettings.test.ts.snap
+++ b/test/unitTests/fileSettings/__snapshots__/fileSettings.test.ts.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`invalid yaml invalid0.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "This yaml does not match the schema for our settings: Properties key-not-allowed are not allowed!",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;
+
+exports[`invalid yaml invalid1.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "This yaml does not match the schema for our settings: /trace/server: must be equal to one of the allowed values (off,messages,verbose)",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;
+
+exports[`invalid yaml invalid2.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "This yaml does not match the schema for our settings: /trace/server: must be string (string)",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;
+
+exports[`invalid yaml invalid3.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "This yaml does not match the schema for our settings: /paths/additional: must be array (array)",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;
+
+exports[`invalid yaml invalid4.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "This yaml does not match the schema for our settings: /paths/additional/1: must be string (string)",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;
+
+exports[`invalid yaml invalid5.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "This yaml does not match the schema for our settings: /analysis/conditionalAnalysis/banana: must be string (string)",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;
+
+exports[`invalid yaml invalid6.vhdl-linter.yml 1`] = `
+[
+  {
+    "message": "Not valid yaml: Flow map must end with a } at line 1, column 23:
+
+{ this is invalid yaml
+                      ^
+",
+    "range": {
+      "end": {
+        "character": 23,
+        "line": 0,
+      },
+      "start": {
+        "character": 22,
+        "line": 0,
+      },
+    },
+    "severity": 1,
+  },
+]
+`;

--- a/test/unitTests/fileSettings/fileSettings.test.ts
+++ b/test/unitTests/fileSettings/fileSettings.test.ts
@@ -21,6 +21,7 @@ test.each(
   const url = pathToFileURL(join(__dirname, fileName));
   const fileSettings = await FileCacheSettings.create(url, await ProjectParser.create([]));
   expect(fileSettings.settings).toBeUndefined();
+  expect(fileSettings.messages).toMatchSnapshot();
 });
 
 test("valid simple yaml", async () => {

--- a/test/unitTests/fileSettings/invalid6.vhdl-linter.yml
+++ b/test/unitTests/fileSettings/invalid6.vhdl-linter.yml
@@ -1,0 +1,1 @@
+{ this is invalid yaml


### PR DESCRIPTION
Similar errors are also report by the yaml extension which we recommend to install. However, now the parser no longer silently ignores any errors.